### PR TITLE
[fix]: plain.jar 생성 비활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,3 +25,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+jar {
+    	enabled = false
+}


### PR DESCRIPTION
의존성이 포함되지 않는 plain.jar 가 생성되는 것을 막습니다.